### PR TITLE
Add 'name' attribute for Berkshelf to work

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,4 +3,5 @@ maintainer_email "andrew@avit.ca"
 license          "Apache 2.0"
 description      "Installs V8 javascript libraries"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.0"
+version          "0.1.1"
+name             "chef-v8"


### PR DESCRIPTION
Berkshelf complains about the missing name attribute for chef-v8. This just adds it in and bumps version number.
